### PR TITLE
"fastsync" command & screensaver deactivated sync option

### DIFF
--- a/default.py
+++ b/default.py
@@ -102,7 +102,7 @@ class Main:
             # Other functions
             if mode == "settings":
                 xbmc.executebuiltin('Addon.OpenSettings(plugin.video.emby)')
-            elif mode in ("manualsync", "repair"):
+            elif mode in ("manualsync", "fastsync", "repair"):
                 if utils.window('emby_online') != "true":
                     # Server is not online, do not run the sync
                     xbmcgui.Dialog().ok(heading="Emby for Kodi",
@@ -116,6 +116,8 @@ class Main:
                     lib = librarysync.LibrarySync()
                     if mode == "manualsync":
                         librarysync.ManualSync().sync(dialog=True)
+                    elif mode == "fastsync":
+                        lib.startSync()
                     else:
                         lib.fullSync(repair=True)
                 else:

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -298,6 +298,7 @@
     <string id="30533">Duration of the music library pop up (in seconds)</string>
     <string id="30534">Server messages</string>
     <string id="30535">Generate a new device Id</string>
+    <string id="30536">Sync when screensaver is deactivated</string>
 
     <!-- service add-on -->
     <string id="33000">Welcome</string>

--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -205,5 +205,12 @@ class KodiMonitor(xbmc.Monitor):
             xbmc.sleep(10000)
             utils.window('emby_onWake', value="true")
 
+
+        elif method == "GUI.OnScreensaverDeactivated":
+            if utils.settings('dbSyncScreensaver') == "true":
+                xbmc.sleep(1000);
+                utils.window('emby_onWake', value="true")
+
+
         elif method == "Playlist.OnClear":
             pass

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -32,6 +32,7 @@
 		<setting id="enableTextureCache" label="30512"  type="bool" default="true" />
         <setting id="imageCacheLimit" type="enum" label="30513" values="Disabled|5|10|15|20|25" default="0" visible="eq(-1,true)" subsetting="true" />
 		<setting id="syncEmptyShows" type="bool" label="30508" default="false" />
+		<setting id="dbSyncScreensaver" label="30536" type="bool" default="false" />
 		<setting id="useDirectPaths" type="enum" label="30511" values="Addon(Default)|Native(Direct paths)" default="0" />
 		<setting id="enableMusic" type="bool" label="30509" default="true" />
 		<setting id="streamMusic" type="bool" label="30510" default="false" visible="eq(-1,true)" subsetting="true" />


### PR DESCRIPTION
Android media player devices turn off the network interfaces once the device has been in sleep for a certain amount of time. When this happens, Kodi will no longer receive live sync notifications from the Emby server. When the device is awake again, the network interfaces are switched back on, but the Kodi database is now out of sync to any changes that were made while the interfaces were off. The user is then forced to restart Kodi, or go to Video Addons > Emby > Manual Sync. These devices are generally low powered and slow, so these tasks take a considerable amount of time. Performing an incremental sync is much more desirable.
The only event that triggers when the device is turned back on, is `GUI.OnScreensaverDeactivated`. `System.OnWake` is not called, because Android does not put the Kodi app to sleep, only the network/screen and throttles the CPU.

So there are two options: Bind `RunPlugin(plugin://plugin.video.emby/?mode=fastsync)` in the keymap to a button on your remote control (this is precious real estate)
Or automatically run sync when screensaver is deactivated. This is of course the most convenient option, has been working fantastic for me. I've added it to Settings > Sync Options, default to false.

Tested on a Sony Bravia X85C running AndroidTV 5.1.1, and an OUYA running CyanogenMod 4.4