### PR TITLE
Add "Force Transcode Hi10P" Bool to Global Settings

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -299,6 +299,7 @@
     <string id="30534">Server messages</string>
     <string id="30535">Generate a new device Id</string>
     <string id="30536">Sync when screensaver is deactivated</string>
+    <string id="30537">Force Transcode Hi10P</string>    
 
     <!-- service add-on -->
     <string id="33000">Welcome</string>

--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -102,11 +102,15 @@ class PlayUtils():
 
         videotrack = self.item['MediaSources'][0]['Name']
         transcodeH265 = settings('transcodeH265')
-        videoprofile = self.item['MediaSources'][0]['Profile']
-        transcodeHi10P = settings('transcodeHi10P')        
-
-        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in videoprofile:
-            return False
+        videoprofiles = self.item['MediaSources'][0]['MediaStreams']
+        streamprofiles = []
+        for vprofile in videoprofiles:
+            if "Profile" in vprofile:
+                streamprofiles.append(vprofile['Profile'])
+        transcodeHi10P = utils.settings('transcodeHi10P')        
+        
+        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in streamprofiles:
+            return False   
             
         if transcodeH265 in ("1", "2", "3") and ("HEVC" in videotrack or "H265" in videotrack):
             # Avoid H265/HEVC depending on the resolution
@@ -212,11 +216,15 @@ class PlayUtils():
 
         videotrack = self.item['MediaSources'][0]['Name']
         transcodeH265 = utils.settings('transcodeH265')
-        videoprofile = self.item['MediaSources'][0]['Profile']
-        transcodeHi10P = settings('transcodeHi10P')        
-
-        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in videoprofile:
-            return False        
+        videoprofiles = self.item['MediaSources'][0]['MediaStreams']
+        streamprofiles = []
+        for vprofile in videoprofiles:
+            if "Profile" in vprofile:
+                streamprofiles.append(vprofile['Profile'])
+        transcodeHi10P = utils.settings('transcodeHi10P')        
+        
+        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in streamprofiles:
+            return False   
 
         if transcodeH265 in ("1", "2", "3") and ("HEVC" in videotrack or "H265" in videotrack):
             # Avoid H265/HEVC depending on the resolution

--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -18,7 +18,7 @@ class PlayUtils():
     def __init__(self, item):
 
         self.item = item
-
+        self.logMsg(self.item)
         self.clientInfo = clientinfo.ClientInfo()
         self.addonName = self.clientInfo.getAddonName()
 

--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -102,7 +102,7 @@ class PlayUtils():
 
         videotrack = self.item['MediaSources'][0]['Name']
         transcodeH265 = settings('transcodeH265')
-        videoprofile = self.item['MediaSources'][1]['Name']
+        videoprofile = self.item['MediaSources'][0]['Profile']
         transcodeHi10P = settings('transcodeHi10P')        
 
         if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in videoprofile:
@@ -212,7 +212,7 @@ class PlayUtils():
 
         videotrack = self.item['MediaSources'][0]['Name']
         transcodeH265 = utils.settings('transcodeH265')
-        videoprofile = self.item['MediaSources'][1]['Name']
+        videoprofile = self.item['MediaSources'][0]['Profile']
         transcodeHi10P = settings('transcodeHi10P')        
 
         if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in videoprofile:

--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -101,16 +101,12 @@ class PlayUtils():
 
         videotrack = self.item['MediaSources'][0]['Name']
         transcodeH265 = settings('transcodeH265')
-        videoprofiles = self.item['MediaSources'][0]['MediaStreams']
-        streamprofiles = []
-        for vprofile in videoprofiles:
-            if "Profile" in vprofile:
-                streamprofiles.append(vprofile['Profile'])
+        videoprofiles = [x['Profile'] for x in self.item['MediaSources'][0]['MediaStreams'] if 'Profile' in x]
         transcodeHi10P = utils.settings('transcodeHi10P')        
-        
-        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in streamprofiles:
+
+        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in videoprofiles:
             return False   
-            
+
         if transcodeH265 in ("1", "2", "3") and ("HEVC" in videotrack or "H265" in videotrack):
             # Avoid H265/HEVC depending on the resolution
             resolution = int(videotrack.split("P", 1)[0])
@@ -215,14 +211,10 @@ class PlayUtils():
 
         videotrack = self.item['MediaSources'][0]['Name']
         transcodeH265 = utils.settings('transcodeH265')
-        videoprofiles = self.item['MediaSources'][0]['MediaStreams']
-        streamprofiles = []
-        for vprofile in videoprofiles:
-            if "Profile" in vprofile:
-                streamprofiles.append(vprofile['Profile'])
+        videoprofiles = [x['Profile'] for x in self.item['MediaSources'][0]['MediaStreams'] if 'Profile' in x]
         transcodeHi10P = utils.settings('transcodeHi10P')        
-        
-        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in streamprofiles:
+
+        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in videoprofiles:
             return False   
 
         if transcodeH265 in ("1", "2", "3") and ("HEVC" in videotrack or "H265" in videotrack):

--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -18,7 +18,6 @@ class PlayUtils():
     def __init__(self, item):
 
         self.item = item
-        self.logMsg(self.item)
         self.clientInfo = clientinfo.ClientInfo()
         self.addonName = self.clientInfo.getAddonName()
 

--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -102,7 +102,12 @@ class PlayUtils():
 
         videotrack = self.item['MediaSources'][0]['Name']
         transcodeH265 = settings('transcodeH265')
+        videoprofile = self.item['MediaSources'][1]['Name']
+        transcodeHi10P = settings('transcodeHi10P')        
 
+        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in videoprofile:
+            return False
+            
         if transcodeH265 in ("1", "2", "3") and ("HEVC" in videotrack or "H265" in videotrack):
             # Avoid H265/HEVC depending on the resolution
             resolution = int(videotrack.split("P", 1)[0])
@@ -207,6 +212,11 @@ class PlayUtils():
 
         videotrack = self.item['MediaSources'][0]['Name']
         transcodeH265 = utils.settings('transcodeH265')
+        videoprofile = self.item['MediaSources'][1]['Name']
+        transcodeHi10P = settings('transcodeHi10P')        
+
+        if transcodeHi10P == "true" and "H264" in videotrack and "High 10" in videoprofile:
+            return False        
 
         if transcodeH265 in ("1", "2", "3") and ("HEVC" in videotrack or "H265" in videotrack):
             # Avoid H265/HEVC depending on the resolution

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -55,6 +55,7 @@
 	    <setting id="playFromStream" type="bool" label="30002" default="false" />
 	    <setting id="videoBitrate" type="enum" label="30160" values="664 Kbps SD|996 Kbps HD|1.3 Mbps HD|2.0 Mbps HD|3.2 Mbps HD|4.7 Mbps HD|6.2 Mbps HD|7.7 Mbps HD|9.2 Mbps HD|10.7 Mbps HD|12.2 Mbps HD|13.7 Mbps HD|15.2 Mbps HD|16.7 Mbps HD|18.2 Mbps HD|20.0 Mbps HD|40.0 Mbps HD|100.0 Mbps HD [default]|1000.0 Mbps HD" visible="true" default="17" subsetting="true" />
 	    <setting id="transcodeH265" type="enum" label="30522" default="0" values="Disabled|480p(and higher)|720p(and higher)|1080p" />
+	    <setting id="transcodeHi10P" type="bool" label="30537" visible="eq(-1,true)" default="false" subsetting="true" />	    
 	    <setting id="markPlayed" type="number" visible="false" default="90" />
 	    <setting id="failedCount" type="number" visible="false" default="0" />
 	    <setting id="networkCreds" type="text" visible="false" default="" />

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -55,7 +55,7 @@
 	    <setting id="playFromStream" type="bool" label="30002" default="false" />
 	    <setting id="videoBitrate" type="enum" label="30160" values="664 Kbps SD|996 Kbps HD|1.3 Mbps HD|2.0 Mbps HD|3.2 Mbps HD|4.7 Mbps HD|6.2 Mbps HD|7.7 Mbps HD|9.2 Mbps HD|10.7 Mbps HD|12.2 Mbps HD|13.7 Mbps HD|15.2 Mbps HD|16.7 Mbps HD|18.2 Mbps HD|20.0 Mbps HD|40.0 Mbps HD|100.0 Mbps HD [default]|1000.0 Mbps HD" visible="true" default="17" subsetting="true" />
 	    <setting id="transcodeH265" type="enum" label="30522" default="0" values="Disabled|480p(and higher)|720p(and higher)|1080p" />
-	    <setting id="transcodeHi10P" type="bool" label="30537" visible="eq(-1,true)" default="false" subsetting="true" />	    
+	    <setting id="transcodeHi10P" type="bool" label="30537" default="false"/>	    
 	    <setting id="markPlayed" type="number" visible="false" default="90" />
 	    <setting id="failedCount" type="number" visible="false" default="0" />
 	    <setting id="networkCreds" type="text" visible="false" default="" />


### PR DESCRIPTION
Added/tested "Force Encode Hi10P" global setting.  When switched on (True) player will force transcode any video containing the High 10 (Hi10P) profile, presenting the user with the Transcode menu (Select audio stream/subtitles)