### PR TITLE
screensaver deactivated sync delay increase

### DIFF
--- a/resources/lib/kodimonitor.py
+++ b/resources/lib/kodimonitor.py
@@ -208,7 +208,7 @@ class KodiMonitor(xbmc.Monitor):
 
         elif method == "GUI.OnScreensaverDeactivated":
             if utils.settings('dbSyncScreensaver') == "true":
-                xbmc.sleep(1000);
+                xbmc.sleep(5000);
                 utils.window('emby_onWake', value="true")
 
 


### PR DESCRIPTION
Update on https://github.com/MediaBrowser/plugin.video.emby/pull/34

I've increased the screensaver deactivation sync delay to 5 seconds because some networks take a long time to re-connect, otherwise the library monitor thread crashes.