### PR TITLE
fix getPlatform

### DIFF
--- a/resources/lib/clientinfo.py
+++ b/resources/lib/clientinfo.py
@@ -62,10 +62,12 @@ class ClientInfo():
             return "iOS"
         elif xbmc.getCondVisibility('system.platform.windows'):
             return "Windows"
-        elif xbmc.getCondVisibility('system.platform.linux'):
-            return "Linux/RPi"
-        elif xbmc.getCondVisibility('system.platform.android'): 
+        elif xbmc.getCondVisibility('system.platform.android'):
             return "Linux/Android"
+        elif xbmc.getCondVisibility('system.platform.linux.raspberrypi'): 
+            return "Linux/RPi"
+        elif xbmc.getCondVisibility('system.platform.linux'): 
+            return "Linux"
         else:
             return "Unknown"
 


### PR DESCRIPTION
xbmc.getCondVisibility('system.platform.linux') returns true in all the following cases: android, raspberry pi, and linux. By reordering the if statement this can be fixed.