### PR TITLE
Add feature to play video on kodi start

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+version 2.3.35
+ - DB connection management revamped
+ - Emby video nodes now have their own parent node
+ - Kodi 17 Ratings
+ - Thread pool system for Emby data loading
+ - A lot of small bug fixes
+ - Some code refactoring
+
 version 2.3.25
 - Fix on-wake sync
 


### PR DESCRIPTION
Add compatibility with kody usage.
Video can now be start by using : 
```
kodi "plugin://plugin.video.emby.movies/?dbid=879&mode=play&id=4998255703280465dee772e9f0a970de&filename=Scream.mkv"
``` 

This feature is useful to project deblockt/kodi-recommendations-for-android-tv. This project need to run kodi with video URL as parameter.

resolve MediaBrowser/plugin.video.emby#35
