### PR TITLE
Ensure transcoding for hi10p videos when requested

### DIFF
--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -303,6 +303,11 @@ class PlayUtils():
                 "%s&VideoCodec=h264&AudioCodec=ac3&MaxAudioChannels=6&deviceId=%s&VideoBitrate=%s"
                 % (playurl, deviceId, self.getBitrate()*1000))
 
+            # Limit to 8 bit if user selected transcode Hi10P
+            transcodeHi10P = settings('transcodeHi10P')
+            if transcodeHi10P == "true":
+                playurl = "%s&MaxVideoBitDepth=8" % playurl
+
         return playurl
 
     def getBitrate(self):


### PR DESCRIPTION
If the user selected transcoding of hi10p videos, send MaxVideoBitDepth=8 with the request.

On my system, hi10p videos were correctly being routed to the transcoding URL, but in the server since the requested and actual codec are H.264, emby isn't transcoding the video stream. This may or may not be related to the fact that the audio stream was flac and was being transcoded. The video stream that was being served was the original video stream, muxed in with the transcoded audio stream. This fix correctly starts video transcoding for me.

I can provide logs if requested, but the fix seems pretty common-sense to me.