### PR TITLE
Fixed broken DTS-HD_ma and DTS-HD_hra flags

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -197,8 +197,11 @@ class API(object):
             'language': stream.get('Language')
         }
 
-        if "dca" in codec and "dts-hd ma" in profile:
+        if "dts-hd ma" in profile:
             track['codec'] = "dtshd_ma"
+
+        if "dts-hd hra" in profile:
+            track['codec'] = "dtshd_hra"
 
         audio_tracks.append(track)
 


### PR DESCRIPTION
This PR will fix the issue that DTS-HD flags won't be set correctly in Kodi.

See reported error in the forum:
 https://emby.media/community/index.php?/topic/44121-kodi-doesn%C2%B4t-show-hd-soundformats/
