### PR TITLE
missing dbid parameter

### DIFF
--- a/resources/lib/playbackutils.py
+++ b/resources/lib/playbackutils.py
@@ -202,7 +202,7 @@ class PlaybackUtils():
 
         if homeScreen and seektime and window('emby_customPlaylist') != "true":
             log.info("Play as a widget item.")
-            self.setListItem(listitem)
+            self.setListItem(listitem, dbid)
             xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, listitem)
 
         elif ((introsPlaylist and window('emby_customPlaylist') == "true") or


### PR DESCRIPTION
If you resume a movie from the homescreen using add-on playback mode the artwork would not be added.
Tested on Kodi 17.1 but not kodi 16.
Before change 
![screenshot 30](https://cloud.githubusercontent.com/assets/5567553/24680982/b3682e6a-1958-11e7-99f0-eed028ca05c0.png)

After change
![screenshot 31](https://cloud.githubusercontent.com/assets/5567553/24680999/cb381d34-1958-11e7-9bb1-a84b17bf9ba7.png)
