### PR TITLE
add resolution limit

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -354,5 +354,6 @@
     <string id="33093">Backup folder</string>
     <string id="33094">Select content type to repair</string>
     <string id="33095">Failed to retrieve latest updates using fast sync, using full sync.</string>
+    <string id="33096">Limit video resolution to screen resolution</string>
 
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -347,4 +347,6 @@
     <string id="33086">Alle zwischengespeicherten Bilder entfernen?</string>
     <string id="33087">Alle Emby Addon-Einstellungen zurücksetzen?</string>
     <string id="33088">Zurücksetzen der Datenbank abgeschlossen, Kodi wird nun neustarten um die Änderungen anzuwenden.</string>
+    <string id="33096">Video Auflösung auf Bildschirm Auflösung limitieren</string>
+
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -54,7 +54,8 @@
 	    <setting id="videoBitrate" type="enum" label="30160" values="664 Kbps SD|996 Kbps HD|1.3 Mbps HD|2.0 Mbps HD|3.2 Mbps HD|4.7 Mbps HD|6.2 Mbps HD|7.7 Mbps HD|9.2 Mbps HD|10.7 Mbps HD|12.2 Mbps HD|13.7 Mbps HD|15.2 Mbps HD|16.7 Mbps HD|18.2 Mbps HD|20.0 Mbps HD|25.0 Mbps HD|30.0 Mbps HD|35.0 Mbps HD|40.0 Mbps HD|100.0 Mbps HD [default]|1000.0 Mbps HD" visible="true" default="20" subsetting="true" />
 	    <setting id="enableExternalSubs" type="bool" label="Enable external subs for direct stream" default="true" />
 	    <setting id="transcodeH265" type="enum" label="30522" default="0" values="Disabled|480p(and higher)|720p(and higher)|1080p" />
-	    <setting id="transcodeHi10P" type="bool" label="30537" default="false"/>	    
+	    <setting id="transcodeHi10P" type="bool" label="30537" default="false"/>
+	    <setting id="limitResolution" type="bool" label="33096" default="false"/>
 	    <setting id="markPlayed" type="number" visible="false" default="90" />
 	    <setting id="failedCount" type="number" visible="false" default="0" />
 	    <setting id="networkCreds" type="text" visible="false" default="" />


### PR DESCRIPTION
This feature implements a settings option to adjust the video resolution to the screen resolution. 

It solves the problems that occur when you want to watch a 4k source on device that only supports 1080p (such as the raspberry pi). 

Idea: add the parameters "maxWidth" and "maxHeight" to the playurl when the option is enabled and the video resolution exceeds the screen resolution.