### PR TITLE
Add support for Kodi XML excludes

### DIFF
--- a/resources/lib/objects/movies.py
+++ b/resources/lib/objects/movies.py
@@ -4,12 +4,14 @@
 
 import logging
 import urllib
+import re
+import xml.etree.ElementTree as etree
 
 import api
 import embydb_functions as embydb
 import _kodi_movies
 from _common import Items, catch_except
-from utils import window, settings, language as lang
+from utils import window, settings, language as lang, advancedSettingsXML
 
 ##################################################################################################
 
@@ -22,6 +24,8 @@ class Movies(Items):
 
 
     def __init__(self, embycursor, kodicursor, pdialog=None):
+
+        self.advsettings = advancedSettingsXML()
 
         self.embycursor = embycursor
         self.emby_db = embydb.Embydb_Functions(self.embycursor)
@@ -219,6 +223,11 @@ class Movies(Items):
             # Direct paths is set the Kodi way
             if not self.path_validation(playurl):
                 return False
+
+            # Exclude video on match
+            for regexp in self.advsettings.findall("./video/excludefromscan/regexp"):
+               if re.search(regexp.text, playurl, re.UNICODE) is not None:
+                    return False
 
             path = playurl.replace(filename, "")
             window('emby_pathverified', value="true")

--- a/resources/lib/objects/tvshows.py
+++ b/resources/lib/objects/tvshows.py
@@ -4,13 +4,15 @@
 
 import logging
 import urllib
+import re
+import xml.etree.ElementTree as etree
 from ntpath import dirname
 
 import api
 import embydb_functions as embydb
 import _kodi_tvshows
 from _common import Items, catch_except
-from utils import window, settings, language as lang
+from utils import window, settings, language as lang, advancedSettingsXML
 
 ##################################################################################################
 
@@ -23,6 +25,8 @@ class TVShows(Items):
 
 
     def __init__(self, embycursor, kodicursor, pdialog=None):
+
+        self.advsettings = advancedSettingsXML()
 
         self.embycursor = embycursor
         self.emby_db = embydb.Embydb_Functions(self.embycursor)
@@ -588,6 +592,11 @@ class TVShows(Items):
             # Direct paths is set the Kodi way
             if not self.path_validation(playurl):
                 return False
+
+            # Exclude episode on match
+            for regexp in self.advsettings.findall("./video/excludetvshowsfromscan/regexp"):
+                if re.search(regexp.text, playurl, re.UNICODE) is not None:
+                    return False
 
             path = playurl.replace(filename, "")
             window('emby_pathverified', value="true")

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -211,6 +211,21 @@ def profiling(sortby="cumulative"):
 #################################################################################################
 # Addon utilities
 
+def advancedSettingsXML():
+    # To prevent scanning regex paths
+    path = xbmc.translatePath("special://masterprofile/").decode('utf-8')
+    xmlpath = "%sadvancedsettings.xml" % path
+
+    try:
+        xmlparse = etree.parse(xmlpath)
+    except: # Document is blank or missing
+        root = etree.Element('advancedsettings')
+    else:
+        root = xmlparse.getroot()    
+
+    # Return root element
+    return root
+
 def sourcesXML():
     # To make Master lock compatible
     path = xbmc.translatePath("special://profile/").decode('utf-8')


### PR DESCRIPTION
This request allows for media to be excluded from Emby's scan if the path matches that of the regular expression found in the kodi advancedsettings.xml. An example:

`<advancedsettings>`
`    <video>`
`        <!-- VideoExtras: Section Start -->`
`        <excludefromscan action="append">`
`            <regexp>/Extras/</regexp>`
`            <regexp>[\\/]Extras[\\/]</regexp>`
`        </excludefromscan>`
`        <excludetvshowsfromscan action="append">`
`            <regexp>/Extras/</regexp>`
`            <regexp>[\\/]Extras[\\/]</regexp>`
`        </excludetvshowsfromscan>`
`        <!-- VideoExtras: Section End -->`
`    </video>`
`</advancedsettings>`

This would exclude any media found beyond the 'Extras' folder.

If their is nothing set or the advancedsettings.xml file is missing, an empty tag will be used and no excludes will take place.