### PR TITLE
Add browse folders item in menu

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -354,5 +354,6 @@
     <string id="33093">Backup folder</string>
     <string id="33094">Select content type to repair</string>
     <string id="33095">Failed to retrieve latest updates using fast sync, using full sync.</string>
+    <string id="33096">Browse folders</string>
 
 </strings>

--- a/resources/lib/entrypoint.py
+++ b/resources/lib/entrypoint.py
@@ -92,6 +92,9 @@ def doMainListing():
                 elif not xbmc.getCondVisibility("Window.IsActive(Videos) | Window.IsActive(Pictures) | Window.IsActive(Music)"):
                     addDirectoryItem(label, path)
 
+    addDirectoryItem(lang(33096),
+        "plugin://plugin.video.emby/?mode=browsecontent&type=folders&id=Folders")
+
     # experimental live tv nodes
     if not xbmc.getCondVisibility("Window.IsActive(Pictures)"):
         addDirectoryItem(lang(33051),


### PR DESCRIPTION
This commit adds a "browse folders" item in the emby addon's menu. When the option "Display a folder view to show plain media folders" is enabled on the server, this menu will browse the new "Folders" node.

Maybe this is not the best way to go to implement the feature. Also, when opening a video that needs transcoding from this menu, there will be no subtitles, emby won't even ask.