### PR TITLE
Use .get to avoid continued KeyError exception

### DIFF
--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -140,10 +140,10 @@ class PlayUtils():
             return False
         
         vid = self.getVideoStreamID()
-        videotrack = self.item['MediaStreams'][vid]['DisplayTitle']
+        videotrack = self.item['MediaStreams'][vid].get('DisplayTitle', '')
         transcodeH265 = settings('transcodeH265')
-        videoprofile = self.item['MediaStreams'][vid]['Profile']
-        transcodeHi10P = settings('transcodeHi10P')        
+        videoprofile = self.item['MediaStreams'][vid].get('Profile', '')
+        transcodeHi10P = settings('transcodeHi10P')
 
         if transcodeHi10P == "true" and ("Main 10" in videoprofile or "High 10" in videoprofile) and ("H264" in videotrack or "H265" in videotrack or "HEVC" in videotrack):
             return False   
@@ -244,10 +244,10 @@ class PlayUtils():
     def isDirectStream(self):
         
         vid = self.getVideoStreamID()
-        videotrack = self.item['MediaStreams'][vid]['DisplayTitle']
+        videotrack = self.item['MediaStreams'][vid].get('DisplayTitle', '')
         transcodeH265 = settings('transcodeH265')
-        videoprofile = self.item['MediaStreams'][vid]['Profile']
-        transcodeHi10P = settings('transcodeHi10P')        
+        videoprofile = self.item['MediaStreams'][vid].get('Profile', '')
+        transcodeHi10P = settings('transcodeHi10P')
 
         if transcodeHi10P == "true" and ("Main 10" in videoprofile or "High 10" in videoprofile) and ("H264" in videotrack or "H265" in videotrack or "HEVC" in videotrack):
             return False   


### PR DESCRIPTION
After a fresh install of Kodi and this plugin my videos stopped playing. Nothing has changed on my central Emby server and in fact another box running an older install but same version works just fine. 

This has been the consistent error I'm seeing:
```
20:06:32.147 T:1710224288  NOTICE: EMBY.playbackutils -> Play called.
20:06:32.154 T:1710224288  NOTICE: EMBY.playutils -> Can't direct play, play from HTTP enabled.
20:06:32.158 T:1710224288   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.KeyError'>
                                            Error Contents: ('DisplayTitle',)
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.emby.movies/default.py", line 50, in <module>
                                                entrypoint.doPlayback(itemid, dbid)
                                              File "/storage/.kodi/addons/plugin.video.emby/resources/lib/entrypoint.py", line 46, in doPlayback
                                                pbutils.PlaybackUtils(item).play(itemId, dbId)
                                              File "/storage/.kodi/addons/plugin.video.emby/resources/lib/playbackutils.py", line 57, in play
                                                playurl = playutils.getPlayUrl()
                                              File "/storage/.kodi/addons/plugin.video.emby/resources/lib/playutils.py", line 102, in getPlayUrl
                                                elif self.isDirectStream():
                                              File "/storage/.kodi/addons/plugin.video.emby/resources/lib/playutils.py", line 247, in isDirectStream
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.emby.tvshows/default.py", line 50, in <module>
                                                entrypoint.doPlayback(itemid, dbid)
                                              File "/storage/.kodi/addons/plugin.video.emby/resources/lib/entrypoint.py", line 46, in doPlayback
                                                pbutils.PlaybackUtils(item).play(itemId, dbId)
                                              File "/storage/.kodi/addons/plugin.video.emby/resources/lib/playbackutils.py", line 57, in play
                                                playurl = playutils.getPlayUrl()
                                              File "/storage/.kodi/addons/plugin.video.emby/resources/lib/playutils.py", line 102, in getPlayUrl
                                                elif self.isDirectStream():
                                              File "/storage/.kodi/addons/plugin.video.emby/resources/lib/playutils.py", line 247, in isDirectStream
                                                videotrack = self.item['MediaStreams'][vid]['DisplayTitle']
                                            KeyError: ('DisplayTitle',)
                                            -->End of Python script error report<--
20:02:44.059 T:1428681632 WARNING: CPythonInvoker(7, /storage/.kodi/addons/plugin.video.emby.tvshows/default.py): the python script "/storage/.kodi/addons/plugin.video.emby.tvshows/default.py" has left several classes in memory that we couldn't clean up. The classes include: N9XBMCAddon9xbmcaddon5AddonE
```

Hotpatching the code to use `.get()` worked perfectly in correcting the issue so here's the PR. Checking the `DisplayTitle` and `Profile` string for certain words/phrases seems pretty arbitrary so this little fix should hopefully prevent anyone else from having the same issue.