### PR TITLE
Update Icon Url

### DIFF
--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -115,7 +115,7 @@ class DownloadUtils(object):
                 "Mute,Unmute,SetVolume,"
                 "Play,Playstate,PlayNext,PlayMediaSource"
             ),
-            'IconUrl': "https://kodi.wiki/images/8/8e/Thumbnail-symbol-transparent.png",
+            'IconUrl': "https://raw.githubusercontent.com/MediaBrowser/Emby.Resources/master/images/devices/kodi.png",
         }
 
         try:


### PR DESCRIPTION
Updated the Icon URL to emby resources repository.
The old link did not work properly.
![image](https://user-images.githubusercontent.com/14938497/42532563-8f2e1b36-8487-11e8-9bed-ac499336a0dc.png)
![image](https://user-images.githubusercontent.com/14938497/42532611-b3ba7eea-8487-11e8-8fde-f576261863c8.png)
