### PR TITLE
Fix incorrect screen resolution for transcoding

### DIFF
--- a/resources/lib/playutils.py
+++ b/resources/lib/playutils.py
@@ -629,6 +629,6 @@ class PlayUtils():
         }
 
     def get_resolution(self):
-
-        window = xbmcgui.Window()
-        return window.getWidth(), window.getHeight()
+        screenWidth = int(xbmc.getInfoLabel('System.ScreenWidth'))
+        screenHeight = int(xbmc.getInfoLabel('System.ScreenHeight'))
+        return screenWidth, screenHeight


### PR DESCRIPTION
Previous function incorrectly returns fixed gui resolution of 1280x720 in all instances, rather than actual resolution.