### PR TITLE
Fix rating id for movies, tv shows and episodes

### DIFF
--- a/resources/lib/objects/_kodi_tvshows.py
+++ b/resources/lib/objects/_kodi_tvshows.py
@@ -194,9 +194,9 @@ class KodiTVShows(KodiItems):
             '''
             INSERT INTO episode(
                 idEpisode, idFile, c00, c01, c03, c04, c05, c09, c10, c12, c13, c14,
-                idShow, c15, c16, idSeason)
+                idShow, c15, c16, idSeason, c20)
 
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             '''
         )
         self.cursor.execute(query, (args))
@@ -206,7 +206,8 @@ class KodiTVShows(KodiItems):
 
             "UPDATE episode",
             "SET c00 = ?, c01 = ?, c03 = ?, c04 = ?, c05 = ?, c09 = ?, c10 = ?,",
-                "c12 = ?, c13 = ?, c14 = ?, c15 = ?, c16 = ?, idSeason = ?, idShow = ?",
+                "c12 = ?, c13 = ?, c14 = ?, c15 = ?, c16 = ?, idSeason = ?, idShow = ?,",
+                "c20 = ?",
             "WHERE idEpisode = ?"
         ))
         self.cursor.execute(query, (args))

--- a/resources/lib/objects/movies.py
+++ b/resources/lib/objects/movies.py
@@ -259,7 +259,7 @@ class Movies(Items):
             self.kodi_db.update_uniqueid(movieid, "movie", imdb, "imdb", uniqueid)
 
             # Update the movie entry
-            self.kodi_db.update_movie(title, plot, shortplot, tagline, votecount, uniqueid,
+            self.kodi_db.update_movie(title, plot, shortplot, tagline, votecount, ratingid,
                                       writer, year, uniqueid, sorttitle, runtime, mpaa, genre,
                                       director, title, studio, trailer, country, year, movieid)
 
@@ -285,7 +285,7 @@ class Movies(Items):
 
             # Create the movie entry
             self.kodi_db.add_movie(movieid, fileid, title, plot, shortplot, tagline,
-                                   votecount, uniqueid, writer, year, uniqueid, sorttitle,
+                                   votecount, ratingid, writer, year, uniqueid, sorttitle,
                                    runtime, mpaa, genre, director, title, studio, trailer,
                                    country, year)
 

--- a/resources/lib/objects/tvshows.py
+++ b/resources/lib/objects/tvshows.py
@@ -354,7 +354,7 @@ class TVShows(Items):
             self.kodi_db.update_uniqueid(showid, "tvshow", tvdb, "tvdb", uniqueid)
 
             # Update the tvshow entry
-            self.kodi_db.update_tvshow(title, plot, uniqueid, premieredate, genre, title,
+            self.kodi_db.update_tvshow(title, plot, ratingid, premieredate, genre, title,
                                        uniqueid, mpaa, studio, sorttitle, showid)
 
             # Update the checksum in emby table
@@ -380,7 +380,7 @@ class TVShows(Items):
             pathid = self.kodi_db.add_path(path)
 
             # Create the tvshow entry
-            self.kodi_db.add_tvshow(showid, title, plot, uniqueid, premieredate, genre,
+            self.kodi_db.add_tvshow(showid, title, plot, ratingid, premieredate, genre,
                                     title, uniqueid, mpaa, studio, sorttitle)
 
             # Create the reference in emby table
@@ -606,9 +606,9 @@ class TVShows(Items):
             self.kodi_db.update_uniqueid(episodeid, "episode", tvdb, "tvdb", uniqueid)
 
             # Update the episode entry
-            self.kodi_db.update_episode(title, plot, uniqueid, writer, premieredate, runtime,
+            self.kodi_db.update_episode(title, plot, ratingid, writer, premieredate, runtime,
                                         director, season, episode, title, airsBeforeSeason,
-                                        airsBeforeEpisode, seasonid, showid, episodeid)
+                                        airsBeforeEpisode, seasonid, showid, uniqueid, episodeid)
 
             # Update the checksum in emby table
             emby_db.updateReference(itemid, checksum)
@@ -633,9 +633,9 @@ class TVShows(Items):
             fileid = self.kodi_db.add_file(filename, pathid)
 
             # Create the episode entry
-            self.kodi_db.add_episode(episodeid, fileid, title, plot, uniqueid, writer,
+            self.kodi_db.add_episode(episodeid, fileid, title, plot, ratingid, writer,
                                      premieredate, runtime, director, season, episode, title,
-                                     showid, airsBeforeSeason, airsBeforeEpisode, seasonid)
+                                     showid, airsBeforeSeason, airsBeforeEpisode, seasonid, uniqueid)
 
             # Create the reference in emby table
             emby_db.addReference(itemid, episodeid, "Episode", "episode", fileid, pathid,


### PR DESCRIPTION
On movies, tv shows and episode tables, ratingid column was being updated with uniqueid values. Also, uniqueid was not being correctly set for episodes at all.