### PR TITLE
Fix force hi10p transcoding behavior

### DIFF
--- a/resources/lib/helper/playutils.py
+++ b/resources/lib/helper/playutils.py
@@ -422,6 +422,7 @@ class PlayUtils(object):
             profile['CodecProfiles'].append(
                 {
                     'Type': 'Video',
+                    'codec': 'h264',
                     'Conditions': [
                         {
                             'Condition': "LessThanEqual",


### PR DESCRIPTION
Fixes the "Force Hi10p transcoding" option to only apply to h264 video codecs