### PR TITLE
Fix server version check in connection_manager.py

### DIFF
--- a/resources/lib/emby/core/connection_manager.py
+++ b/resources/lib/emby/core/connection_manager.py
@@ -8,6 +8,7 @@ import hashlib
 import socket
 import time
 from datetime import datetime
+from distutils.version import LooseVersion
 
 from credentials import Credentials
 from http import HTTP
@@ -471,26 +472,15 @@ class ConnectionManager(object):
             1 a is larger
             0 equal
         '''
-        a = a.split('.')
-        b = b.split('.')
+        a = LooseVersion(a)
+        b = LooseVersion(b)
 
-        for i in range(0, max(len(a), len(b)), 1):
-            try:
-                aVal = a[i]
-            except IndexError:
-                aVal = 0
+        if a < b:
+            return -1
 
-            try:    
-                bVal = b[i]
-            except IndexError:
-                bVal = 0
-
-            if aVal < bVal:
-                return -1
-
-            if aVal > bVal:
-                return 1
-
+        if a > b:
+            return 1
+        
         return 0
 
     def _string_equals_ignore_case(self, str1, str2):


### PR DESCRIPTION
Changed to use version comparison from distutils.

Comparing versions as strings treats 10 < 9. Comparing as integers breaks for versions like 1a. Using LooseVersion() handles both cases.