### PR TITLE
workaround for resuming in dsplayer 17.6

### DIFF
--- a/resources/lib/hooks/player.py
+++ b/resources/lib/hooks/player.py
@@ -312,7 +312,12 @@ class Player(xbmc.Player):
 
                 item['Runtime'] = 0
                 LOG.info("Runtime is missing, Using Zero")
-
+                
+        # workaround for resume in dsplayer 17.6        
+        if xbmc.getCondVisibility('System.HasAddon(script.madvrsettings)'):
+            if item.get('CurrentPosition'):
+                self.seekTime(item.get('CurrentPosition'))   
+                
         try:
             seektime = self.get_time()
         except Exception: # at this point we should be playing and if not then bail out


### PR DESCRIPTION
I believe 'System.HasAddon(script.madvrsettings)' should only apply to kodi dsplayer.

the testing i have done so far seems to indicate it is working fine (dsplayer 17.6 with 4.1.19).
its resumes as expected.
it starts from the beginning if so selected.
