### PR TITLE
Fix an encoding error when syncing database

### DIFF
--- a/emby/views.py
+++ b/emby/views.py
@@ -652,7 +652,7 @@ class Views():
 
     def node_nextepisodes(self, root, LibraryName):
         params = {
-            'libraryname': LibraryName,
+            'libraryname': LibraryName.encode('utf-8'),
             'mode': "nextepisodes",
             'limit': 25
         }


### PR DESCRIPTION
# Issue

Failed to update existing databases from the remote server. However, the first-time sync works fine for some reason.

# Logs
```
......
2021-06-27 01:00:17.565 T:6468   DEBUG: DEBUG: EMBY.database.database: --->[ database: emby ] 2404193102608
2021-06-27 01:00:17.567 T:6468  NOTICE: INFO: EMBY.database.database: [emby] 2 rows updated.
2021-06-27 01:00:17.573 T:6468   DEBUG: DEBUG: EMBY.database.database: ---<[ database: emby ] 2404193102608
2021-06-27 01:00:17.587 T:6468   DEBUG: DEBUG: EMBY.database.database: --->[ database: emby ] 2404193102608
2021-06-27 01:00:17.595 T:6468   DEBUG: DEBUG: EMBY.emby.views.Views: {'libraryname': u'\u7535\u89c6\u8282\u76ee', 'limit': 25, 'mode': 'nextepisodes'}    <<---------------------- ADDED DEBUGGING OUTPUT
2021-06-27 01:00:17.595 T:6468   ERROR: ERROR: EMBY.database.database: type: <type 'exceptions.UnicodeEncodeError'> value: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)
2021-06-27 01:00:17.595 T:6468   DEBUG: DEBUG: EMBY.database.database: ---<[ database: emby ] 2404193102608
2021-06-27 01:00:17.600 T:6468   ERROR: Exception in thread Thread-4:
                                            Traceback (most recent call last):
                                              File "C:\Program Files\Kodi\system\python\Lib\threading.py", line 801, in __bootstrap_inner
                                                self.run()
                                              File "C:\Users\dianlujitao\AppData\Roaming\Kodi\addons\plugin.video.emby-next-gen\database\library.py", line 137, in run
                                                self.Views.update_nodes()
                                              File "C:\Users\dianlujitao\AppData\Roaming\Kodi\addons\plugin.video.emby-next-gen\emby\views.py", line 184, in update_nodes
                                                self.add_nodes(node_path, view)
                                              File "C:\Users\dianlujitao\AppData\Roaming\Kodi\addons\plugin.video.emby-next-gen\emby\views.py", line 414, in add_nodes
                                                self.node_nextepisodes(xmlData, view['Name'])
                                              File "C:\Users\dianlujitao\AppData\Roaming\Kodi\addons\plugin.video.emby-next-gen\emby\views.py", line 660, in node_nextepisodes
                                                path = "%s?%s" % ("plugin://plugin.video.emby-next-gen/", urlencode(params))
                                              File "C:\Program Files\Kodi\system\python\Lib\urllib.py", line 1343, in urlencode
                                                v = quote_plus(str(v))
                                            UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)
2021-06-27 01:00:17.617 T:9764   DEBUG: ------ Window Deinit (DialogExtendedProgressBar.xml) ------
2021-06-27 01:00:19.149 T:9764   DEBUG: ------ Window Deinit (Pointer.xml) ------
......
```
The Unicode string is a Chinese word that translates to "TV shows" (the folder on my emby server is named in Chinese):
```Python console
In [1]: u'\u7535\u89c6\u8282\u76ee'
Out[1]: '电视节目'
```
Force UTF-8 to address the issue.